### PR TITLE
Add caption clipboard

### DIFF
--- a/src/components/caption/components/caption-list-dropdown.tsx
+++ b/src/components/caption/components/caption-list-dropdown.tsx
@@ -1,0 +1,41 @@
+import { ShortcutText } from "@/components/common/shortcut-text"
+import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger } from "@/components/ui"
+import { useCaptionEditor } from "@/hooks/provider/caption-editor-provider";
+import { useCaptionClipboard } from "@/hooks/provider/use-caption-clipboard-provider";
+import { ClipboardCopy, ClipboardPaste, EllipsisVertical, Trash } from "lucide-react"
+
+export const CaptionListDropdown = () => {
+  const { parts, clearParts } = useCaptionEditor();
+  const { copy, paste, hasContent } = useCaptionClipboard();
+  return (
+    <DropdownMenu >
+      <DropdownMenuTrigger>
+        <Button variant="ghost" size={"icon"}><EllipsisVertical /></Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem disabled={parts.length === 0} onClick={copy}>
+          <ClipboardCopy />
+          <span>Copy</span>
+          <DropdownMenuShortcut>
+            <ShortcutText settingsKey="copyCaptionParts" />
+          </DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={!hasContent} onClick={paste}>
+          <ClipboardPaste />
+          <span>Paste</span>
+          <DropdownMenuShortcut>
+            <ShortcutText settingsKey="pasteCaptionParts" />
+          </DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={clearParts} >
+          <Trash />
+          <span>Clear</span>
+          <DropdownMenuShortcut>
+            <ShortcutText settingsKey="clearCaption" />
+          </DropdownMenuShortcut>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/components/caption/components/caption-list.tsx
+++ b/src/components/caption/components/caption-list.tsx
@@ -16,11 +16,10 @@ import { CaptionListFooter } from "./caption-list-footer";
 import { AnimatedGroup } from "@/components/ui/animation/animated-group";
 import { useEffect, useRef } from "react";
 import { useCaptionEditor } from "@/hooks/provider/caption-editor-provider";
-import { Button } from "@/components/ui";
-import { Trash } from "lucide-react";
+import { CaptionListDropdown } from "./caption-list-dropdown";
 
 export const CaptionList = () => {
-  const { parts, handleDragEnd, clearParts } = useCaptionEditor();
+  const { parts, handleDragEnd } = useCaptionEditor();
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -48,7 +47,7 @@ export const CaptionList = () => {
     <div className="border-l ml-2 h-full flex flex-col">
       <div className="flex flex-row gap-2 justify-between items-center mb-2">
         <h1 className="ml-4 font-semibold">Caption Parts </h1>
-        <Button variant={"ghost"} size={"icon"} onClick={clearParts}><Trash /></Button>
+        <CaptionListDropdown />
       </div>
       <div
         className="flex flex-col overflow-y-auto gap-1 pb-4"

--- a/src/components/common/shortcut-keys.tsx
+++ b/src/components/common/shortcut-keys.tsx
@@ -1,21 +1,15 @@
-import { settings, Settings } from "@/lib/settings"
-import { replaceShortcutSymbols } from "@/lib/utils"
+import { Settings } from "@/lib/settings"
 import clsx from "clsx"
-import { useAtom } from "jotai/react"
-import { useMemo } from "react"
+import { ShortcutText } from "./shortcut-text"
 
 type ShortcutKeysProps = {
   settingsKey: keyof Settings["shortcuts"]
 } & Partial<Pick<HTMLSpanElement, "className">>
 
 export const ShortcutKeys = ({ settingsKey, className }: ShortcutKeysProps) => {
-  const [shortcut] = useAtom(settings.shortcuts[settingsKey])
-  const symbolizedShortcut = useMemo(() => replaceShortcutSymbols(shortcut), [shortcut])
-
-
   return (
     <span className={clsx("p-1 border bg-muted rounded-md m-1 font-mono", className)}>
-      {symbolizedShortcut}
+      <ShortcutText settingsKey={settingsKey} />
     </span>
   )
 }

--- a/src/components/common/shortcut-text.tsx
+++ b/src/components/common/shortcut-text.tsx
@@ -1,0 +1,16 @@
+import { settings, Settings } from "@/lib/settings"
+import { replaceShortcutSymbols } from "@/lib/utils"
+import { useAtom } from "jotai/react"
+import { useMemo } from "react"
+
+type ShortcutTextProps = {
+  settingsKey: keyof Settings["shortcuts"]
+}
+
+export const ShortcutText = ({ settingsKey }: ShortcutTextProps) => {
+  const [shortcut] = useAtom(settings.shortcuts[settingsKey])
+  const symbolizedShortcut = useMemo(() => replaceShortcutSymbols(shortcut), [shortcut])
+  return (
+    <>{symbolizedShortcut}</>
+  )
+}

--- a/src/components/settings/content/shortcuts-settings/shortcuts-settings-content.tsx
+++ b/src/components/settings/content/shortcuts-settings/shortcuts-settings-content.tsx
@@ -14,6 +14,9 @@ const ShortcutsSettingsContent = () => {
         <ShortcutRow settingsKey="previousImage" title="Previous image" description="Load the previous image from the image sidebar" />
         <ShortcutRow settingsKey="nextImage" title="Next image" description="Load the next image from the image sidebar" />
         <ShortcutRow settingsKey="startExport" title="Start export" description="Immediately starts a new export" />
+        <ShortcutRow settingsKey="clearCaption" title="Clear current caption" description="Removes the caption of the currently open image" />
+        <ShortcutRow settingsKey="copyCaptionParts" title="Copy caption parts" description="Copies the currently open picture's caption parts into an internal clipboard" />
+        <ShortcutRow settingsKey="pasteCaptionParts" title="Paste caption parts" description="Adds the caption parts on the internal clipboard into the currently open image's caption" />
       </TableBody>
     </Table >
   );

--- a/src/hooks/provider/caption-editor-provider.tsx
+++ b/src/hooks/provider/caption-editor-provider.tsx
@@ -56,6 +56,9 @@ export const CaptionEditorProvider: React.FC<CaptionEditorProviderProps> = ({
   useShortcut("save", () => {
     save();
   });
+  useShortcut("clearCaption", () => {
+    clearParts();
+  });
 
   const addPart = (text: string) => {
     setParts((prevParts) => [...prevParts, {

--- a/src/hooks/provider/use-caption-clipboard-provider.tsx
+++ b/src/hooks/provider/use-caption-clipboard-provider.tsx
@@ -1,0 +1,62 @@
+import { Caption } from '@/lib/types';
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { useCaptionEditor } from './caption-editor-provider';
+import { useShortcut } from '../use-shortcut';
+
+type CaptionClipboardContextType = {
+  caption: Caption | null;
+  setCaption: (newCaption: Caption) => void;
+  copy: VoidFunction;
+  paste: VoidFunction;
+  clear: VoidFunction;
+  hasContent: boolean;
+};
+
+const CaptionClipboardContext = createContext<CaptionClipboardContextType | undefined>(undefined);
+
+export const CaptionClipboardProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [caption, setCaption] = useState<Caption | null>(null);
+  const { parts, preview, addPart, setPreview } = useCaptionEditor();
+  useShortcut("copyCaptionParts", () => copy());
+  useShortcut("pasteCaptionParts", () => paste());
+
+  const clear = () => {
+    setCaption(null);
+  }
+
+  const copy = () => {
+    setCaption({
+      parts,
+      preview: preview ?? undefined
+    })
+  }
+
+  const paste = () => {
+    if (!caption) {
+      return;
+    }
+    caption.parts.forEach(part => addPart(part.text));
+    setPreview(caption.preview ?? null);
+  }
+
+  return (
+    <CaptionClipboardContext.Provider value={{
+      caption,
+      setCaption,
+      hasContent: !!caption,
+      copy,
+      paste,
+      clear
+    }}>
+      {children}
+    </CaptionClipboardContext.Provider>
+  );
+};
+
+export const useCaptionClipboard = (): CaptionClipboardContextType => {
+  const context = useContext(CaptionClipboardContext);
+  if (!context) {
+    throw new Error('useCaptionClipboard must be used within a CaptionClipboardProvider');
+  }
+  return context;
+};

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -29,13 +29,25 @@ export const settings = {
     ),
     save: atomWithStorage("settings.shortcuts.save", "mod+s"),
     previousImage: atomWithStorage(
-    "settings.shortcuts.previousImage",
+      "settings.shortcuts.previousImage",
       "pageup"
     ),
     nextImage: atomWithStorage("settings.shortcuts.previousImage", "pagedown"),
     startExport: atomWithStorage(
       "settings.shortcuts.startExport",
       "mod+shift+s"
+    ),
+    copyCaptionParts: atomWithStorage(
+      "settings.shortcuts.copyCaptionParts",
+      "mod+shift+c"
+    ),
+    pasteCaptionParts: atomWithStorage(
+      "settings.shortcuts.pasteCaptionParts",
+      "mod+shift+v"
+    ),
+    clearCaption: atomWithStorage(
+      "settings.shortcuts.clearCaption",
+      "mod+shift+delete"
     ),
   },
   caption: {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -105,26 +105,29 @@ export const replaceShortcutSymbols = (
   if (Array.isArray(shortcut)) {
     shortcut = shortcut.join("");
   }
+
+  shortcut = shortcut.toUpperCase();
+
   if (isMacOS()) {
-    shortcut = shortcut.replace("meta", "⌘").replace("mod", "⌘");
+    shortcut = shortcut.replace("META", "⌘").replace("MOD", "⌘");
   }
 
   shortcut = replaceAll(shortcut, "+", "");
-  shortcut = shortcut.replace("shift", "⇧");
-  shortcut = shortcut.replace("alt", "⌥");
-  shortcut = shortcut.replace("ctrl", "⌃");
-  shortcut = shortcut.replace("enter", "↩");
-  shortcut = shortcut.replace("space", "␣");
-  shortcut = shortcut.replace("backspace", "⌫");
-  shortcut = shortcut.replace("delete", "⌦");
-  shortcut = shortcut.replace("escape", "⎋");
-  shortcut = shortcut.replace("tab", "⇥");
-  shortcut = shortcut.replace("pageup", "PgUp");
-  shortcut = shortcut.replace("pagedown", "PgDn");
-  shortcut = shortcut.replace("up", "↑");
-  shortcut = shortcut.replace("down", "↓");
-  shortcut = shortcut.replace("left", "←");
-  shortcut = shortcut.replace("right", "→");
-  shortcut = shortcut.replace("comma", ",");
+  shortcut = shortcut.replace("SHIFT", "⇧");
+  shortcut = shortcut.replace("ALT", "⌥");
+  shortcut = shortcut.replace("CTRL", "⌃");
+  shortcut = shortcut.replace("ENTER", "↩");
+  shortcut = shortcut.replace("SPACE", "␣");
+  shortcut = shortcut.replace("BACKSPACE", "⌫");
+  shortcut = shortcut.replace("DELETE", "⌦");
+  shortcut = shortcut.replace("ESCAPE", "⎋");
+  shortcut = shortcut.replace("TAB", "⇥");
+  shortcut = shortcut.replace("PAGEUP", "PgUp");
+  shortcut = shortcut.replace("PAGEDOWN", "PgDn");
+  shortcut = shortcut.replace("UP", "↑");
+  shortcut = shortcut.replace("DOWN", "↓");
+  shortcut = shortcut.replace("LEFT", "←");
+  shortcut = shortcut.replace("RIGHT", "→");
+  shortcut = shortcut.replace("COMMA", ",");
   return shortcut;
 };

--- a/src/pages/caption/page.tsx
+++ b/src/pages/caption/page.tsx
@@ -3,14 +3,17 @@ import { CaptionSaveToolbar } from "@/components/toolbars/caption-save-toolbar";
 import { ImageNavigationToolbar } from "@/components/toolbars/image-navigation-toolbar";
 import { LensSettingsToolbar } from "@/components/toolbars/lens-settings-toolbar";
 import { CaptionEditorProvider } from "@/hooks/provider/caption-editor-provider";
+import { CaptionClipboardProvider } from "@/hooks/provider/use-caption-clipboard-provider";
 import { ImageListLayout } from "@/layouts/image-list-layout";
 
 export default function Page() {
   return (
     <CaptionEditorProvider>
-      <ImageListLayout toolbars={[LensSettingsToolbar, ImageNavigationToolbar, CaptionSaveToolbar]}>
-        <CaptionView />
-      </ImageListLayout>
+      <CaptionClipboardProvider>
+        <ImageListLayout toolbars={[LensSettingsToolbar, ImageNavigationToolbar, CaptionSaveToolbar]}>
+          <CaptionView />
+        </ImageListLayout>
+      </CaptionClipboardProvider>
     </CaptionEditorProvider>
   );
 }


### PR DESCRIPTION
Captions from one image can now easily be copied and pasted to another image.
It doesn't replace the "Templates" idea, but may already be handy.

<img width="416" alt="SCR-20241103-uayp" src="https://github.com/user-attachments/assets/274ce41b-5829-4b0f-b035-d39d529f0c10">
