### PR TITLE
Add text replacement feature

### DIFF
--- a/src/components/caption/components/caption-input.tsx
+++ b/src/components/caption/components/caption-input.tsx
@@ -4,7 +4,8 @@ import { settings } from "@/lib/settings";
 import clsx from "clsx";
 import { useAtom } from "jotai/react";
 import { ArrowUp, Pencil, X } from "lucide-react";
-import { KeyboardEvent, useEffect, useRef, useState } from "react";
+import { KeyboardEvent, useEffect, useRef } from "react";
+import { useApplyTextReplacements } from "@/hooks/use-apply-text-replacements";
 
 export const EditBanner = ({ onCancel }: { onCancel?: VoidFunction }) => {
   const { isEditing, cancelEditMode } = useCaptionEditor();
@@ -31,7 +32,7 @@ export const EditBanner = ({ onCancel }: { onCancel?: VoidFunction }) => {
 
 export const CaptionInput = () => {
   const [separator] = useAtom(settings.caption.separator);
-  const [value, setValue] = useState("");
+  const [value, setValue] = useApplyTextReplacements();
   const {
     isEditing,
     addPart,

--- a/src/components/category/components/category-input.tsx
+++ b/src/components/category/components/category-input.tsx
@@ -3,10 +3,11 @@ import { settings } from "@/lib/settings";
 import clsx from "clsx";
 import { useAtom } from "jotai/react";
 import { Pencil, X } from "lucide-react";
-import { KeyboardEvent, ReactNode, useEffect, useRef, useState } from "react";
+import { KeyboardEvent, ReactNode, useEffect, useRef } from "react";
 import { useCategoryEditor } from "../category-editor-provider";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useCategorySuggestions } from "../use-category-suggestions";
+import { useApplyTextReplacements } from "@/hooks/use-apply-text-replacements";
 
 const Suggestion = ({ children, onApply, active }: { children: ReactNode, onApply: VoidFunction, active?: boolean }) => {
   return (
@@ -53,7 +54,7 @@ const EditBanner = ({ onCancel }: { onCancel?: VoidFunction }) => {
 
 export const CategoryInput = () => {
   const [separator] = useAtom(settings.category.separator);
-  const [value, setValue] = useState("");
+  const [value, setValue] = useApplyTextReplacements();
   const {
     isEditing,
     addCategory,

--- a/src/components/settings/content/caption-settings/strategy-selector.tsx
+++ b/src/components/settings/content/caption-settings/strategy-selector.tsx
@@ -13,7 +13,7 @@ export const StrategySelector = () => {
   const [strategy, setStrategy] = useAtom(settings.caption.strategy);
 
   return (
-    <Select value={strategy} onValueChange={setStrategy}>
+    <Select value={strategy} onValueChange={(v) => setStrategy(v as "ai" | "separator")}>
       <SelectTrigger>
         <SelectValue placeholder="Strategy" />
       </SelectTrigger>

--- a/src/components/settings/content/index.ts
+++ b/src/components/settings/content/index.ts
@@ -5,11 +5,13 @@ import ShortcutsSettings from "./shortcuts-settings/shortcuts-settings-content";
 import AISettings from "./ai-settings/ai-settings-content";
 import AdvancedSettings from "./advanced-settings/advanced-settings-content";
 import CaptionSettings from "./caption-settings/caption-settings-content";
+import TextReplacementSettings from "./text-replacement-settings/text-replacement-settings-content";
 
 export const navbarItems: SettingsNavbarItem[] = [
   AppearanceSettings,
   ShortcutsSettings,
   CaptionSettings,
+  TextReplacementSettings,
   AISettings,
   AdvancedSettings,
 ];

--- a/src/components/settings/content/text-replacement-settings/text-replacement-settings-content.tsx
+++ b/src/components/settings/content/text-replacement-settings/text-replacement-settings-content.tsx
@@ -1,0 +1,110 @@
+import { Pencil, Plus, Replace, Trash } from "lucide-react";
+import { SettingsNavbarItem } from "../../types";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  Input,
+} from "@/components/ui";
+import { useTextReplacements } from "@/hooks/use-text-replacements";
+import { useState } from "react";
+
+
+const TextReplacementSettingsContent = () => {
+  const [isDialogOpen, setDialogOpen] = useState(false);
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const { replacements, upsertReplacement, removeReplacement } = useTextReplacements();
+
+  const handleAdd = () => {
+    setFrom("");
+    setTo("");
+    setDialogOpen(true);
+  }
+
+  const handleSave = () => {
+    if (from.trim().length === 0 || to.trim().length === 0) {
+      return;
+    }
+    upsertReplacement(from, to);
+    setDialogOpen(false);
+    setFrom("");
+    setTo("");
+  }
+
+  const handleEdit = (replacement: { from: string, to: string }) => {
+    setFrom(replacement.from);
+    setTo(replacement.to);
+    setDialogOpen(true);
+  }
+
+  const handleDelete = (replacement: { from: string, to: string }) => {
+    removeReplacement(replacement.from);
+  }
+
+  const handleCancel = () => {
+    setDialogOpen(false);
+    setFrom("");
+    setTo("");
+  }
+
+  return (
+    <div className="mt-2 flex flex-col gap-2">
+      <div className="px-4 py-2 flex flex-row gap-4 justify-between items-center">
+        <span className="text-muted-foreground">Text replacements allow you to write captions quicker. Sometimes you find yourself typing the same words over and over again. Here text replacements come in handy, just type a shortcut and it will automatically expand into your predefined phrase. Text replacements are only applied while typing, you need to confirm them with a space at the end. This is to avoid accidential overwrites.</span>
+        <Button onClick={handleAdd}><Plus /> Add</Button>
+      </div>
+      <Dialog open={isDialogOpen} onOpenChange={handleCancel}>
+        <DialogContent>
+          <div className="flex flex-col gap-2">
+            <div>
+              <label>Text</label>
+              <Input value={from} onChange={(e) => setFrom(e.target.value)} />
+            </div>
+            <div>
+              <label>Replacement</label>
+              <Input value={to} onChange={(e) => setTo(e.target.value)} />
+            </div>
+          </div>
+          <div className="flex justify-between gap-2">
+            <Button variant={"ghost"} onClick={handleCancel}>Cancel</Button>
+            <Button onClick={handleSave}>Save</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {replacements.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Text</TableHead>
+              <TableHead className="text-right">Replacement</TableHead>
+              <TableHead className="text-right w-[50px]">Action</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {replacements.map((replacement) => (
+              <TableRow key={replacement.from}>
+                <TableCell>{replacement.from}</TableCell>
+                <TableCell className="text-right">{replacement.to}</TableCell>
+                <TableCell className="text-right flex flex-row gap-1">
+                  <Button onClick={() => handleEdit(replacement)} variant="ghost" size="icon"><Pencil /></Button>
+                  <Button onClick={() => handleDelete(replacement)} variant="ghost" size="icon"><Trash /></Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+};
+
+const navbarItem: SettingsNavbarItem = {
+  name: "Text Replacement",
+  icon: Replace,
+  content: <TextReplacementSettingsContent />,
+};
+
+export default navbarItem;

--- a/src/hooks/use-apply-text-replacements.tsx
+++ b/src/hooks/use-apply-text-replacements.tsx
@@ -1,0 +1,22 @@
+import { settings } from "@/lib/settings"
+import { useAtom } from "jotai/react"
+import { useState } from "react"
+
+export const useApplyTextReplacements = () => {
+  const [isEnabled] = useAtom(settings.tools.textReplacement.enabled)
+  const [replacements] = useAtom(settings.tools.textReplacement.replacements)
+  const [value, setValue] = useState("")
+
+  const applyTextReplacement = (input: string) => {
+    let newValue = input
+    if (isEnabled) {
+      replacements.forEach((replacement) => {
+        const pattern = new RegExp(`${replacement.from}\\s$`)
+        newValue = newValue.replace(pattern, replacement.to + " ")
+      })
+    }
+    setValue(newValue)
+  }
+
+  return [value, applyTextReplacement] as const
+}

--- a/src/hooks/use-text-replacements.tsx
+++ b/src/hooks/use-text-replacements.tsx
@@ -1,0 +1,27 @@
+import { settings } from "@/lib/settings"
+import { useAtom } from "jotai/react"
+
+export const useTextReplacements = () => {
+  const [replacements, setReplacements] = useAtom(settings.tools.textReplacement.replacements)
+
+  const upsertReplacement = (from: string, to: string) => {
+    const existing = replacements.find((r) => r.from === from)
+    if (existing) {
+      // update existing replacement
+      setReplacements(replacements.map((r) => (r.from === from ? { from, to } : r)))
+      return
+    } else {
+      setReplacements([...replacements, { from, to }])
+    }
+  }
+  
+  const removeReplacement = (from: string) => {
+    setReplacements(replacements.filter((r) => r.from !== from))
+  }
+
+  return {
+    replacements,
+    upsertReplacement,
+    removeReplacement,
+  }
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -88,6 +88,14 @@ export const settings = {
       zoomFactor: atomWithStorage("settings.tools.lens.zoomFactor", 3),
       size: atomWithStorage("settings.tools.lens.size", 300),
     },
+    textReplacement: {
+      enabled: atomWithStorage("settings.tools.textReplacement.enabled", true),
+      replacements: atomWithZod(
+        "settings.tools.textReplacement.replacements",
+        [],
+        z.array(z.object({ from: z.string(), to: z.string() }))
+      ),
+    },
   },
   ai: {
     ollamaEnabled: atomWithStorage("settings.ai.ollamaEnabled", false),

--- a/src/lib/zod-atom.ts
+++ b/src/lib/zod-atom.ts
@@ -1,5 +1,4 @@
 import { atomWithStorage } from "jotai/utils";
-import { Atom } from "jotai/vanilla";
 import { z } from "zod";
 
 export const atomWithZod = <V, T extends z.Schema<V>>(
@@ -7,25 +6,21 @@ export const atomWithZod = <V, T extends z.Schema<V>>(
   initialValue: z.infer<T>,
   schema: T
 ) => {
-  const theAtom: Atom<z.infer<typeof schema>> = atomWithStorage(
-    storageKey,
-    initialValue,
-    {
-      getItem: (key, initial) => {
-        const storedValue = localStorage.getItem(key);
-        if (!storedValue) {
-          return initial;
-        }
+  const atom = atomWithStorage<z.infer<T>>(storageKey, initialValue, {
+    getItem: (key, initial) => {
+      const storedValue = localStorage.getItem(key);
+      if (!storedValue) {
+        return initial;
+      }
 
-        return schema.parse(JSON.parse(storedValue));
-      },
-      setItem(key, value) {
-        localStorage.setItem(key, JSON.stringify(value));
-      },
-      removeItem(key) {
-        localStorage.removeItem(key);
-      },
-    }
-  );
-  return theAtom;
+      return schema.parse(JSON.parse(storedValue));
+    },
+    setItem(key, value) {
+      localStorage.setItem(key, JSON.stringify(value));
+    },
+    removeItem(key) {
+      localStorage.removeItem(key);
+    },
+  });
+  return atom;
 };


### PR DESCRIPTION
Works while captioning but also while sorting.
I thought about storing them in the dataset database, but I think it's good to keep them separate and usable across datasets.
Regex is supported as well. I didn't promote it in the UI, because I don't know how good this works.

<img width="1328" alt="SCR-20241109-ldts" src="https://github.com/user-attachments/assets/d717be60-e88f-4391-a9c9-1211f3f76f0e">

<img alt="Kapture 2024-11-09 at 12 20 03" src="https://github.com/user-attachments/assets/0f59a524-9f8c-42c1-a6e9-6246c350d13a">
