### PR TITLE
Add auto-save when before unload is triggered

### DIFF
--- a/src/components/caption/caption-editor-provider.tsx
+++ b/src/components/caption/caption-editor-provider.tsx
@@ -55,7 +55,7 @@ export const CaptionEditorProvider: React.FC<CaptionEditorProviderProps> = ({
     initialValue: currentImage?.caption,
   });
 
-  usePreventClose(isDirty);
+  usePreventClose(isDirty, () => save());
   useShortcut("saveCaption", () => {
     save();
   });

--- a/src/components/category/category-editor-provider.tsx
+++ b/src/components/category/category-editor-provider.tsx
@@ -48,7 +48,7 @@ export const CategoryEditorProvider: React.FC<CategoryEditorProviderProps> = ({
   const [editingPart, setEditingPart] = useState<Category | null>(null);
   const previousImage = usePrevious(currentImage);
 
-  usePreventClose(isDirty);
+  usePreventClose(isDirty, () => save());
   useShortcut("saveCategories", () => {
     save();
   });

--- a/src/hooks/provider/prevent-close-provider.tsx
+++ b/src/hooks/provider/prevent-close-provider.tsx
@@ -46,7 +46,8 @@ export const PreventCloseProvider = ({
 };
 
 export const usePreventClose = (
-  initialValue = false
+  initialValue = false,
+  onBeforeUnload?: VoidFunction
 ): PreventCloseContextType => {
   const context = useContext(PreventCloseContext);
 
@@ -59,6 +60,20 @@ export const usePreventClose = (
   useEffect(() => {
     context.setUnsavedWork(initialValue);
   }, [context, initialValue]);
+
+  useEffect(() => {
+    if (!onBeforeUnload || !context.unsavedWork) {
+      return;
+    }
+    const handleBeforeUnload = () => {
+      onBeforeUnload();
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [context.unsavedWork, onBeforeUnload]);
 
   return context;
 };


### PR DESCRIPTION
I think this way of partially auto-saving and partially not is still a good solution, because otherwise images may get labelled as done and even hide from the view, just because the user added a first caption part. This explicit saving while the user is working allows for more control. 
Thats why we had the before unload listener already to warn users when they have unsaved work. I now added that after the browser pop up, work is still auto-saved. It's best effort and only works when the user decides to cancel on the browser pop up and stay on the page. 