### PR TITLE
Load next image before deleting

### DIFF
--- a/src/components/common/delete-image-dialog.tsx
+++ b/src/components/common/delete-image-dialog.tsx
@@ -10,7 +10,7 @@ import { useShortcut } from "@/hooks/use-shortcut";
 
 
 export const DeleteImageDialog = () => {
-  const { currentImage } = useImageNavigation();
+  const { currentImage, loadNextImage, loadPreviousImage, hasNextImage, hasPreviousImage } = useImageNavigation();
   const { imageFiles, deleteFile } = useDatasetDirectory();
   const imageFile = useMemo(() =>
     imageFiles.find((file) => file.name === currentImage?.filename),
@@ -36,6 +36,11 @@ export const DeleteImageDialog = () => {
     setOpen(false);
     if (!imageFile) {
       return;
+    }
+    if (hasNextImage) {
+      loadNextImage();
+    } else if (hasPreviousImage) {
+      loadPreviousImage();
     }
     await deleteFile(imageFile);
     if (deleteCaptionFile && imageFile.captionFile) {

--- a/src/components/common/delete-image-dialog.tsx
+++ b/src/components/common/delete-image-dialog.tsx
@@ -60,7 +60,7 @@ export const DeleteImageDialog = () => {
         <DialogHeader>
           <DialogTitle>Delete image?</DialogTitle>
           <DialogDescription>
-            Are you sure you want to delete <b>{currentImage?.filename}</b>? This will remove the file from your disk and cannot be undone.
+            Are you sure you want to delete <b>{currentImage?.filename}</b>? This will remove the file from your computer and cannot be undone.
           </DialogDescription>
         </DialogHeader>
         {imageFile?.captionFile && (


### PR DESCRIPTION
Small UX improvement, because previously after deletion no image was selected and PgDn would select the first image of the list and one may had to scroll down the entire list.