### PR TITLE
Add feature to prepend new part instead of append

### DIFF
--- a/src/components/caption/caption-editor-provider.tsx
+++ b/src/components/caption/caption-editor-provider.tsx
@@ -18,7 +18,7 @@ import { useDatabase } from "@/lib/database/database-provider";
 interface CaptionEditorContextType {
   parts: CaptionPart[];
   preview: string | null;
-  addPart: (part: string) => void;
+  addPart: (part: string, prepend?: boolean) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handleDragEnd: (event: any) => void;
   enterEditMode: (part: CaptionPart) => void;
@@ -63,12 +63,23 @@ export const CaptionEditorProvider: React.FC<CaptionEditorProviderProps> = ({
     clearParts();
   });
 
-  const addPart = (text: string) => {
-    setParts((prevParts) => [...prevParts, {
-      id: uuid(),
-      text,
-      index: prevParts.length,
-    }]);
+  const addPart = (text: string, prepend?: boolean) => {
+    if (prepend) {
+      setParts((prevParts) => [{
+        id: uuid(),
+        text,
+        index: 0,
+      }, ...prevParts.map((part) => ({
+        ...part,
+        index: part.index + 1,
+      }))]);
+    } else {
+      setParts((prevParts) => [...prevParts, {
+        id: uuid(),
+        text,
+        index: prevParts.length,
+      }]);
+    }
     setDirty(true);
   };
 

--- a/src/components/caption/components/caption-input.tsx
+++ b/src/components/caption/components/caption-input.tsx
@@ -54,7 +54,7 @@ export const CaptionInput = () => {
       .map((text) => text.trim())
       .filter((text) => text !== "");
 
-  const onSubmit = () => {
+  const onSubmit = (prepend = false) => {
     const sanitizedValue = sanitizeValue(value);
     const parts = splitIntoParts(sanitizedValue);
     if (isEditing) {
@@ -73,7 +73,7 @@ export const CaptionInput = () => {
       if (sanitizedValue === "") {
         return;
       }
-      parts.forEach((part) => addPart(part));
+      parts.forEach((part) => addPart(part, prepend));
     }
     setValue("");
   };
@@ -112,7 +112,7 @@ export const CaptionInput = () => {
             }
             onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
               if (event.key === "Enter") {
-                onSubmit();
+                onSubmit(event.shiftKey);
               }
               if (event.key === "ArrowUp") {
                 onEditLast();

--- a/src/components/category/category-editor-provider.tsx
+++ b/src/components/category/category-editor-provider.tsx
@@ -17,7 +17,7 @@ import { ImageEntity } from "@/lib/database/image-entity";
 
 interface CategoryEditorContextType {
   categories: Category[];
-  addCategory: (category: string) => void;
+  addCategory: (category: string, prepend?: boolean) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handleDragEnd: (event: any) => void;
   enterEditMode: (category: Category) => void;
@@ -56,15 +56,27 @@ export const CategoryEditorProvider: React.FC<CategoryEditorProviderProps> = ({
     clearCategories();
   });
 
-  const addCategory = (text: string) => {
+  const addCategory = (text: string, prepend?: boolean) => {
     if (categories.some((item) => item.text === text)) {
       return
     }
-    setCategories((prevCategory) => [...prevCategory, {
-      id: uuid(),
-      text,
-      index: prevCategory.length,
-    }]);
+
+    if (prepend) {
+      setCategories((prevCategory) => [{
+        id: uuid(),
+        text,
+        index: 0,
+      }, ...prevCategory.map((category) => ({
+        ...category,
+        index: category.index + 1,
+      }))]);
+    } else {
+      setCategories((prevCategory) => [...prevCategory, {
+        id: uuid(),
+        text,
+        index: prevCategory.length,
+      }]);
+    }
     setDirty(true);
   };
 

--- a/src/components/category/components/category-input.tsx
+++ b/src/components/category/components/category-input.tsx
@@ -75,7 +75,7 @@ export const CategoryInput = () => {
       .map((text) => text.trim())
       .filter((text) => text !== "");
 
-  const onSubmit = () => {
+  const onSubmit = (prepend = false) => {
     const sanitizedValue = sanitizeValue(value);
     const categories = splitIntoCategories(sanitizedValue);
     if (isEditing) {
@@ -94,7 +94,7 @@ export const CategoryInput = () => {
       if (sanitizedValue === "") {
         return;
       }
-      categories.forEach((category) => addCategory(category));
+      categories.forEach((category) => addCategory(category, prepend));
     }
     setValue("");
   };
@@ -139,7 +139,7 @@ export const CategoryInput = () => {
                     if (selected && !isEditing) {
                       applySuggestion(selected);
                     } else {
-                      onSubmit();
+                      onSubmit(event.shiftKey);
                     }
                   }
                   if (!isEditing && event.key === "ArrowUp") {


### PR DESCRIPTION
Hitting only `Enter` will append the item to the end of the list, like before. Hitting `Shift+Enter` will prepend the item the start of the list.